### PR TITLE
Check for type property in httpRequest method to avoid error

### DIFF
--- a/lib/box-view-api.php
+++ b/lib/box-view-api.php
@@ -244,7 +244,7 @@ class Box_View_API {
     // Close and return the curl response.
     $result = $this->parseResponse($ch, $response);
     curl_close($ch);
-    if (is_object($result->response) && $result->response->type === 'error') {
+    if (is_object($result->response) && property_exists($result->response, 'type') && $result->response->type === 'error') {
       throw new Box_View_Exception('Error: ' . $result->response->message, $result->headers->code);
     }
     return $result;


### PR DESCRIPTION
This is fixing the same issue that stevenmaguire submitted in PR#8, but now is contained on one line of code as requested. Thanks!
